### PR TITLE
feat: sort windows by focus history (most recently used first)

### DIFF
--- a/src/ipc.h
+++ b/src/ipc.h
@@ -37,6 +37,11 @@ int hypr_ipc_get_clients_basic(HyprClientInfo **list_out, size_t *count_out);
 /* Free an array of HyprClientInfo structs allocated by hypr_ipc_get_clients_basic. */
 void hypr_ipc_free_client_infos(HyprClientInfo *infos, size_t count);
 
+/* Sort clients by focus history (most recently focused first).
+   focusHistoryID 0 = currently focused, higher values = older focus.
+   Windows with focusHistoryID -1 (unknown) are placed at the end. */
+void hypr_ipc_sort_clients_by_focus(HyprClientInfo *clients, size_t count);
+
 /* Focus a client by multi-strategy:
    1) Try focusing by address (with "address:" prefix, then raw).
    2) Try focusing by class (escaped).


### PR DESCRIPTION
Implement window sorting based on Hyprland's focusHistoryID so that the switcher displays windows in most-recently-used order, similar to Alt+Tab behavior in Windows/macOS.

Changes:
- Add hypr_ipc_sort_clients_by_focus() to sort clients by focusHistoryID
- Sort windows in both initial load and refresh operations
- Set initial selection to index 1 (previous window) so releasing Alt immediately switches to the last used window
- Index 0 (current window) is preserved for Escape/Cancel restore

Bug fixes:
- Use explicit comparison instead of subtraction in sort comparator to prevent potential integer overflow
- Add NULL checks for strdup() return values with warning logs

The switcher now behaves intuitively:
- Alt+Tab opens with previous window highlighted
- Releasing Alt switches to that window
- Pressing Tab cycles through focus history
- Escape restores original focus

Closes #6